### PR TITLE
Get rid of `Ltd` suffix in copyright header

### DIFF
--- a/examples/hello_world/cpp-client-reader/main_receiver.cc
+++ b/examples/hello_world/cpp-client-reader/main_receiver.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/examples/hello_world/cpp-client-reader/main_receiver.cc
+++ b/examples/hello_world/cpp-client-reader/main_receiver.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/examples/hello_world/cpp-client-sender/main_sender.cc
+++ b/examples/hello_world/cpp-client-sender/main_sender.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/examples/hello_world/cpp-client-sender/main_sender.cc
+++ b/examples/hello_world/cpp-client-sender/main_sender.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/examples/hello_world/model/src/main/proto/hello.proto
+++ b/examples/hello_world/model/src/main/proto/hello.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2017, TeamDev. All rights reserved.
+// Copyright 2018, TeamDev. All rights reserved.
 //
 // Redistribution and use in source and/or binary forms, with or without
 // modification, must retain the above copyright notice and the following

--- a/examples/hello_world/model/src/main/proto/hello.proto
+++ b/examples/hello_world/model/src/main/proto/hello.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2017, TeamDev Ltd. All rights reserved.
+// Copyright 2017, TeamDev. All rights reserved.
 //
 // Redistribution and use in source and/or binary forms, with or without
 // modification, must retain the above copyright notice and the following

--- a/include/spine/actor_request_factory.h
+++ b/include/spine/actor_request_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/actor_request_factory.h
+++ b/include/spine/actor_request_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/actor_request_factory_params.h
+++ b/include/spine/actor_request_factory_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/actor_request_factory_params.h
+++ b/include/spine/actor_request_factory_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/command_factory.h
+++ b/include/spine/command_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/command_factory.h
+++ b/include/spine/command_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/query_factory.h
+++ b/include/spine/query_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/query_factory.h
+++ b/include/spine/query_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/topic_factory.h
+++ b/include/spine/topic_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/topic_factory.h
+++ b/include/spine/topic_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/types.h
+++ b/include/spine/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/types.h
+++ b/include/spine/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/util/any_utils.hpp
+++ b/include/spine/util/any_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/util/message_utils.hpp
+++ b/include/spine/util/message_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/util/message_utils.hpp
+++ b/include/spine/util/message_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/include/spine/util/target_utils.hpp
+++ b/include/spine/util/target_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/actor_request_factory.cc
+++ b/src/actor_request_factory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/actor_request_factory.cc
+++ b/src/actor_request_factory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/actor_request_factory_params.cc
+++ b/src/actor_request_factory_params.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/actor_request_factory_params.cc
+++ b/src/actor_request_factory_params.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/command_factory.cc
+++ b/src/command_factory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/command_factory.cc
+++ b/src/command_factory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/query_factory.cc
+++ b/src/query_factory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/query_factory.cc
+++ b/src/query_factory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/topic_factory.cc
+++ b/src/topic_factory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/src/topic_factory.cc
+++ b/src/topic_factory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/test/actor_request_factory_params_test.cc
+++ b/test/actor_request_factory_params_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/test/actor_request_factory_test.cc
+++ b/test/actor_request_factory_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/test/command_factory_test.cc
+++ b/test/command_factory_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/test/common_factory_test.h
+++ b/test/common_factory_test.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/test/query_factory_test.cc
+++ b/test/query_factory_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/test/topic_factory_test.cc
+++ b/test/topic_factory_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/test/unit_tests.proto
+++ b/test/unit_tests.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2018, TeamDev Ltd. All rights reserved.
+// Copyright 2018, TeamDev. All rights reserved.
 //
 // Redistribution and use in source and/or binary forms, with or without
 // modification, must retain the above copyright notice and the following

--- a/test/unit_tests_no_prefix.proto
+++ b/test/unit_tests_no_prefix.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2018, TeamDev Ltd. All rights reserved.
+// Copyright 2018, TeamDev. All rights reserved.
 //
 // Redistribution and use in source and/or binary forms, with or without
 // modification, must retain the above copyright notice and the following


### PR DESCRIPTION
This PR fixes issue https://github.com/SpineEventEngine/core-java/issues/699 for `client-cpp` repository.

All files having header format 

```
Copyright *year*, TeamDev Ltd. All rights reserved.
```

now have
```
Copyright 2018, TeamDev. All rights reserved.
```